### PR TITLE
Makes the lid effect shut down more cleanly

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,34 @@
+[
+  {
+    "label": "Debug lidprobe",
+    "adapter": "Swift",
+    "request": "launch",
+    "program": "$ZED_WORKTREE_ROOT/.build/debug/lidprobe",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "build": "swift: Build Debug lidprobe"
+  },
+  {
+    "label": "Release lidprobe",
+    "adapter": "Swift",
+    "request": "launch",
+    "program": "$ZED_WORKTREE_ROOT/.build/release/lidprobe",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "build": "swift: Build Release lidprobe"
+  },
+  {
+    "label": "Debug MacDuo",
+    "adapter": "Swift",
+    "request": "launch",
+    "program": "$ZED_WORKTREE_ROOT/.build/debug/MacDuo",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "build": "swift: Build Debug MacDuo"
+  },
+  {
+    "label": "Release MacDuo",
+    "adapter": "Swift",
+    "request": "launch",
+    "program": "$ZED_WORKTREE_ROOT/.build/release/MacDuo",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "build": "swift: Build Release MacDuo"
+  }
+]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,30 @@
+[
+  {
+    "label": "swift: Build Debug lidprobe",
+    "command": "swift",
+    "args": ["build", "--configuration", "debug", "--product", "lidprobe"],
+    "use_new_terminal": false,
+    "allow_concurrent_runs": true
+  },
+  {
+    "label": "swift: Build Release lidprobe",
+    "command": "swift",
+    "args": ["build", "--configuration", "release", "--product", "lidprobe"],
+    "use_new_terminal": false,
+    "allow_concurrent_runs": true
+  },
+  {
+    "label": "swift: Build Debug MacDuo",
+    "command": "swift",
+    "args": ["build", "--configuration", "debug", "--product", "MacDuo"],
+    "use_new_terminal": false,
+    "allow_concurrent_runs": true
+  },
+  {
+    "label": "swift: Build Release MacDuo",
+    "command": "swift",
+    "args": ["build", "--configuration", "release", "--product", "MacDuo"],
+    "use_new_terminal": false,
+    "allow_concurrent_runs": true
+  }
+]

--- a/Sources/MacDuo/CapturedFrame.swift
+++ b/Sources/MacDuo/CapturedFrame.swift
@@ -1,0 +1,15 @@
+import CoreVideo
+import Metal
+
+/// A captured texture with Core Video owner prevents pixel buffer from
+/// being recycled while GPU is still reading it.
+struct CapturedFrame: @unchecked Sendable {
+    let texture: MTLTexture
+    private let owner: CVMetalTexture
+
+    init?(_ owner: CVMetalTexture) {
+        guard let texture = CVMetalTextureGetTexture(owner) else { return nil }
+        self.texture = texture
+        self.owner = owner
+    }
+}

--- a/Sources/MacDuo/DepthOverlay.swift
+++ b/Sources/MacDuo/DepthOverlay.swift
@@ -172,7 +172,7 @@ final class DepthOverlay {
 
     /// Hands one live frame to the renderer and reveals the window once the
     /// first one has landed.
-    func absorb(_ frame: MTLTexture) {
+    func absorb(_ frame: CapturedFrame) {
         guard window != nil, let renderer else { return }
         renderer.absorb(frame)
         reveal()

--- a/Sources/MacDuo/DepthRenderer.swift
+++ b/Sources/MacDuo/DepthRenderer.swift
@@ -59,7 +59,7 @@ final class DepthRenderer {
     private var liveScale: CGFloat = 0
     private var isLiveSource = false
     /// The newest live frame, waiting for the next drawn frame to take it.
-    private var pendingFrame: MTLTexture?
+    private var pendingFrame: CapturedFrame?
     /// A held picture to start from, waiting for the same moment. A live
     /// frame that arrives first wins, since it is the newer of the two.
     private var pendingSeed: (buffer: MTLBuffer, width: Int, height: Int)?
@@ -289,7 +289,7 @@ final class DepthRenderer {
         return true
     }
 
-    func absorb(_ frame: MTLTexture) {
+    func absorb(_ frame: CapturedFrame) {
         guard isLiveSource, liveTexture != nil else { return }
         pendingFrame = frame
         pendingSeed = nil
@@ -304,11 +304,11 @@ final class DepthRenderer {
         let inset = Int((Self.paddingInPoints * pixelScale).rounded())
         guard let blit = commands.makeBlitCommandEncoder() else { return }
         if let frame = pendingFrame {
-            let width = min(frame.width, target.width - 2 * inset)
-            let height = min(frame.height, target.height - 2 * inset)
+            let width = min(frame.texture.width, target.width - 2 * inset)
+            let height = min(frame.texture.height, target.height - 2 * inset)
             guard width > 0, height > 0 else { blit.endEncoding(); return }
             blit.copy(
-                from: frame,
+                from: frame.texture,
                 sourceSlice: 0,
                 sourceLevel: 0,
                 sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
@@ -318,6 +318,9 @@ final class DepthRenderer {
                 destinationLevel: 0,
                 destinationOrigin: MTLOrigin(x: inset, y: inset, z: 0)
             )
+            commands.addCompletedHandler { [frame] _ in
+                withExtendedLifetime(frame) {}
+            }
         } else if let seed = pendingSeed {
             let width = min(seed.width, target.width - 2 * inset)
             let height = min(seed.height, target.height - 2 * inset)

--- a/Sources/MacDuo/LidController.swift
+++ b/Sources/MacDuo/LidController.swift
@@ -29,6 +29,8 @@ final class LidController: ObservableObject {
     private let overlay = DepthOverlay()
     private let streamer = ScreenStreamer()
 
+    private var enabledSubscription: AnyCancellable?
+    private var pictureTask: Task<Void, Never>?
     private var pollTimer: Timer?
     private var pollInterval: TimeInterval = 0
     private var displayLink: CADisplayLink?
@@ -96,6 +98,12 @@ final class LidController: ObservableObject {
 
     init(preferences: Preferences) {
         self.preferences = preferences
+        enabledSubscription = preferences.$isEnabled
+            .removeDuplicates()
+            .sink { [weak self] enabled in
+                guard !enabled else { return }
+                self?.disableEffect()
+            }
     }
 
     // MARK: - Lifecycle
@@ -133,17 +141,34 @@ final class LidController: ObservableObject {
         pollTimer?.invalidate()
         pollTimer = nil
         pollInterval = 0
+        stopEffectAndCapture()
+    }
+
+    private func stopEffectAndCapture() {
+        pictureTask?.cancel()
+        pictureTask = nil
+        isCapturePending = false
         stopDisplayLink()
         overlay.dismiss(animated: false)
-        snapshotter.endPrewarm()
+        snapshotter.stop()
         streamer.stop()
         overlay.discardLive()
+        preview = nil
         isActive = false
+    }
+
+    private func disableEffect() {
+        stopEffectAndCapture()
+        lastChangedAngle = nil
+        angularVelocity = 0
+        lastClosingTime = -.greatestFiniteMagnitude
+        lastMovedDownTime = -.greatestFiniteMagnitude
+        if pollTimer != nil { setPollInterval(Self.idlePollInterval) }
     }
 
     /// Plays the effect once on the current screen contents.
     func runPreview() {
-        guard preview == nil, !isActive else { return }
+        guard preferences.isEnabled, !isSuspended, preview == nil, !isActive else { return }
         // Well above the trigger angle, so the sweep runs the pre-warm the way
         // a real close does.
         preview = PreviewRun(
@@ -201,13 +226,16 @@ final class LidController: ObservableObject {
         }
 
         rawAngle = angle
-        updateVelocity(with: angle)
         publish(angle: angle)
 
-        reconcile(angle: angle)
+        if preferences.isEnabled {
+            updateVelocity(with: angle)
+            reconcile(angle: angle)
+        }
 
         let prewarmZone = preferences.thresholdAngle + preferences.prewarmCeiling
-        let wantsFastPolling = preview != nil || isActive || angle <= prewarmZone + Self.fastPollMargin
+        let wantsFastPolling = preferences.isEnabled
+            && (preview != nil || isActive || angle <= prewarmZone + Self.fastPollMargin)
         setPollInterval(wantsFastPolling ? Self.activePollInterval : Self.idlePollInterval)
     }
 
@@ -228,6 +256,7 @@ final class LidController: ObservableObject {
     /// Brings the screen in line with `wantsEffect` on every sample. A run
     /// whose screenshot failed is retried here.
     private func reconcile(angle: Double) {
+        guard preferences.isEnabled, !isSuspended else { return }
         let wanted = wantsEffect(angle: angle)
         if wanted != isActive {
             Diagnostics.lid.notice(
@@ -337,6 +366,7 @@ final class LidController: ObservableObject {
     /// Shows the held screenshot, or waits for one. A pre-warm capture that is
     /// already running counts as that wait.
     private func presentPicture() {
+        guard preferences.isEnabled, !isSuspended, isActive else { return }
         if preferences.isLivePicture, let screen = NSScreen.builtIn,
            overlay.showLive(
                on: screen,
@@ -367,9 +397,12 @@ final class LidController: ObservableObject {
             return
         }
         isCapturePending = true
-        Task { [weak self] in
-            guard let self else { return }
+        pictureTask?.cancel()
+        pictureTask = Task { [weak self] in
+            guard let self, !Task.isCancelled else { return }
             await self.snapshotter.captureOnce()
+            guard !Task.isCancelled else { return }
+            self.pictureTask = nil
             self.isCapturePending = false
             Diagnostics.lid.notice(
                 """
@@ -389,9 +422,12 @@ final class LidController: ObservableObject {
     private func requestSeed() {
         isCapturePending = true
         let started = CACurrentMediaTime()
-        Task { [weak self] in
-            guard let self else { return }
+        pictureTask?.cancel()
+        pictureTask = Task { [weak self] in
+            guard let self, !Task.isCancelled else { return }
             await self.snapshotter.captureOnce()
+            guard !Task.isCancelled else { return }
+            self.pictureTask = nil
             self.isCapturePending = false
             Diagnostics.lid.notice(
                 """
@@ -514,15 +550,7 @@ final class LidController: ObservableObject {
     private func suspend() {
         Diagnostics.lid.notice("suspend")
         isSuspended = true
-        stopDisplayLink()
-        overlay.dismiss(animated: false)
-        snapshotter.endPrewarm()
-        snapshotter.discard()
-        streamer.stop()
-        overlay.discardLive()
-        preview = nil
-        isActive = false
-        isCapturePending = false
+        stopEffectAndCapture()
     }
 
     private func resume() {

--- a/Sources/MacDuo/ScreenSnapshotter.swift
+++ b/Sources/MacDuo/ScreenSnapshotter.swift
@@ -52,6 +52,13 @@ final class ScreenSnapshotter {
         timer = nil
     }
 
+    func stop() {
+        endPrewarm()
+        inFlight?.cancel()
+        inFlight = nil
+        discard()
+    }
+
     /// Drops the held screenshot.
     func discard() {
         latestImage = nil
@@ -80,6 +87,7 @@ final class ScreenSnapshotter {
         if let inFlight { return inFlight }
         let task = Task { [weak self] in
             await self?.performCapture()
+            guard !Task.isCancelled else { return }
             self?.inFlight = nil
         }
         inFlight = task
@@ -87,11 +95,12 @@ final class ScreenSnapshotter {
     }
 
     private func performCapture() async {
+        guard !Task.isCancelled else { return }
         guard let screen = NSScreen.builtIn, let displayID = screen.displayID else { return }
         if filter == nil || filterDisplayID != displayID {
             await rebuildFilter(displayID: displayID)
         }
-        guard let activeFilter = filter else { return }
+        guard !Task.isCancelled, let activeFilter = filter else { return }
 
         let configuration = SCStreamConfiguration()
         configuration.width = Int(activeFilter.contentRect.width * CGFloat(activeFilter.pointPixelScale))
@@ -106,6 +115,7 @@ final class ScreenSnapshotter {
                 contentFilter: activeFilter,
                 configuration: configuration
             )
+            guard !Task.isCancelled else { return }
             let elapsed = (CFAbsoluteTimeGetCurrent() - started) * 1000
             latestImage = image
             latestScreen = screen
@@ -125,6 +135,7 @@ final class ScreenSnapshotter {
                 Diagnostics.geometry.notice("capture: \(geometry, privacy: .public)")
             }
         } catch {
+            guard !Task.isCancelled else { return }
             filter = nil
             filterDisplayID = nil
         }
@@ -137,6 +148,7 @@ final class ScreenSnapshotter {
                 false,
                 onScreenWindowsOnly: true
             )
+            guard !Task.isCancelled else { return }
             Diagnostics.geometry.notice(
                 "SCShareableContent took \((CFAbsoluteTimeGetCurrent() - started) * 1000, format: .fixed(precision: 1)) ms"
             )
@@ -154,6 +166,7 @@ final class ScreenSnapshotter {
             )
             filterDisplayID = displayID
         } catch {
+            guard !Task.isCancelled else { return }
             filter = nil
             filterDisplayID = nil
         }

--- a/Sources/MacDuo/ScreenStreamer.swift
+++ b/Sources/MacDuo/ScreenStreamer.swift
@@ -3,7 +3,6 @@ import CoreVideo
 import Metal
 import ScreenCaptureKit
 
-/// A live picture of the built-in display, handed over as Metal textures.
 ///
 /// Frames are `IOSurface` backed, so wrapping one as a texture copies nothing.
 /// `startCapture` takes long enough that the stream has to be started while
@@ -21,7 +20,7 @@ final class ScreenStreamer {
     private final class Receiver: NSObject, SCStreamOutput {
         private let cache: CVMetalTextureCache
         private let lock = NSLock()
-        private var newest: CVMetalTexture?
+        private var newest: CapturedFrame?
         private var newestID: UInt64 = 0
 
         init?(device: MTLDevice) {
@@ -33,11 +32,11 @@ final class ScreenStreamer {
         }
 
         /// The newest frame and its number, or `nil` before the first one.
-        func latest() -> (texture: MTLTexture, id: UInt64)? {
+        func latest() -> (frame: CapturedFrame, id: UInt64)? {
             lock.lock()
             defer { lock.unlock() }
-            guard let newest, let texture = CVMetalTextureGetTexture(newest) else { return nil }
-            return (texture, newestID)
+            guard let newest else { return nil }
+            return (newest, newestID)
         }
 
         func stream(
@@ -64,10 +63,11 @@ final class ScreenStreamer {
                 0,
                 &wrapped
             )
-            guard result == kCVReturnSuccess, let wrapped else { return }
+            guard result == kCVReturnSuccess, let wrapped,
+                  let frame = CapturedFrame(wrapped) else { return }
 
             lock.lock()
-            newest = wrapped
+            newest = frame
             newestID &+= 1
             lock.unlock()
         }
@@ -138,13 +138,13 @@ final class ScreenStreamer {
 
     /// The newest frame, but only once. `nil` when nothing new has arrived
     /// since the last call.
-    func newFrame() -> MTLTexture? {
+    func newFrame() -> CapturedFrame? {
         let now = CACurrentMediaTime()
         guard now - lastHandOver >= Self.minimumHandOverInterval else { return nil }
         guard let latest = receiver?.latest(), latest.id != consumedID else { return nil }
         consumedID = latest.id
         lastHandOver = now
-        return latest.texture
+        return latest.frame
     }
 
     private func begin(displayID: CGDirectDisplayID, on target: NSScreen) async {

--- a/Sources/MacDuo/ScreenStreamer.swift
+++ b/Sources/MacDuo/ScreenStreamer.swift
@@ -103,6 +103,7 @@ final class ScreenStreamer {
         isStarted = true
         startTask = Task { [weak self] in
             await self?.begin(displayID: displayID, on: target)
+            guard !Task.isCancelled else { return }
             self?.startTask = nil
         }
     }
@@ -147,6 +148,7 @@ final class ScreenStreamer {
     }
 
     private func begin(displayID: CGDirectDisplayID, on target: NSScreen) async {
+        guard !Task.isCancelled else { return }
         guard let device, let receiver = Receiver(device: device) else {
             isStarted = false
             return
@@ -155,7 +157,7 @@ final class ScreenStreamer {
             if filter == nil || filterDisplayID != displayID {
                 await rebuildFilter(displayID: displayID)
             }
-            guard isStarted, let activeFilter = filter else { return }
+            guard !Task.isCancelled, isStarted, let activeFilter = filter else { return }
 
             let configuration = SCStreamConfiguration()
             configuration.width = Int(activeFilter.contentRect.width * CGFloat(activeFilter.pointPixelScale))
@@ -175,7 +177,7 @@ final class ScreenStreamer {
             )
             let started = CFAbsoluteTimeGetCurrent()
             try await fresh.startCapture()
-            guard isStarted else {
+            guard !Task.isCancelled, isStarted else {
                 try? await fresh.stopCapture()
                 return
             }
@@ -189,6 +191,7 @@ final class ScreenStreamer {
                 """
             )
         } catch {
+            guard !Task.isCancelled else { return }
             Diagnostics.geometry.error("stream failed: \(String(describing: error), privacy: .public)")
             invalidateFilter()
             isStarted = false
@@ -201,6 +204,7 @@ final class ScreenStreamer {
                 false,
                 onScreenWindowsOnly: true
             )
+            guard !Task.isCancelled else { return }
             guard let display = content.displays.first(where: { $0.displayID == displayID }) else {
                 invalidateFilter()
                 return
@@ -218,6 +222,7 @@ final class ScreenStreamer {
             )
             filterDisplayID = displayID
         } catch {
+            guard !Task.isCancelled else { return }
             Diagnostics.geometry.error("stream filter failed: \(String(describing: error), privacy: .public)")
             invalidateFilter()
         }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+#:schema https://mise.jdx.dev/schema/mise.json
+
+[tools]
+swift = "latest"


### PR DESCRIPTION
When the feature is being disabled or the app is suspended, pending screen captures are now cancelled instead of being allowed to finish later and further update state

It also improves lifetime of live captured frames btw. Live ScreenCaptureKit frames are wrapped so the underlying Core Video texture owner stays alive until the GPU has finished reading from it, according to [Apple's best practice](https://developer.apple.com/videos/play/wwdc2022/110565/?time=1153)