### PR TITLE
fix: use the built-in lid sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ macOS may require Screen Recording permission again after rebuilding with ad-hoc
 ## Known limitations
 
 - Only MacBooks with a compatible lid angle sensor can use the effect. The app reports when no sensor is available.
+- Sensor discovery requires an Apple orientation sensor marked as built-in by macOS and a supported angle report, without relying on a specific product ID. External display sensors are excluded.
 - The effect applies only to the built-in display.
 - The effect stops when macOS sleeps as the lid closes.
 - Clicks pass through the effect to the apps underneath.

--- a/Sources/LidAngleKit/LidAngleSensor.swift
+++ b/Sources/LidAngleKit/LidAngleSensor.swift
@@ -78,14 +78,14 @@ public final class LidAngleSensor {
         let degrees: Double
         switch resolution {
         case .hundredthsOfADegree:
-            guard bytes.count == 5 else { return nil }
+            guard bytes.count >= 5 else { return nil }
             let raw = UInt32(bytes[1])
                 | UInt32(bytes[2]) << 8
                 | UInt32(bytes[3]) << 16
                 | UInt32(bytes[4]) << 24
             degrees = Double(raw) / 100
         case .wholeDegrees:
-            guard bytes.count == 3 else { return nil }
+            guard bytes.count >= 3 else { return nil }
             degrees = Double(UInt16(bytes[1]) | UInt16(bytes[2]) << 8)
         }
 

--- a/Sources/LidAngleKit/LidAngleSensor.swift
+++ b/Sources/LidAngleKit/LidAngleSensor.swift
@@ -4,9 +4,9 @@ import IOKit.hid
 
 /// Reads the lid hinge angle from the MacBook orientation sensor.
 ///
-/// The sensor is an `AppleSPUHIDDevice`, vendor `0x05AC`, product `0x8104`, on
-/// HID usage page `0x20`, usage `0x8A`. Two reports carry the same angle, both
-/// through `kIOHIDReportTypeFeature`:
+/// Discovers Apple's built-in orientation sensors on HID usage page `0x20`,
+/// usage `0x8A`, without requiring a specific product ID. Supported angle reports use
+/// `kIOHIDReportTypeFeature`:
 ///
 /// - Report 1: 3 bytes `[0x01, lo, hi]`, whole degrees, 0...360.
 /// - Report 7: 5 bytes `[0x07, b0, b1, b2, b3]`, little-endian hundredths of a
@@ -73,18 +73,19 @@ public final class LidAngleSensor {
     public func angle() -> Double? {
         guard let resolution else { return nil }
         guard let bytes = read(reportID: resolution.reportID) else { return nil }
+        guard bytes.first == UInt8(resolution.reportID) else { return nil }
 
         let degrees: Double
         switch resolution {
         case .hundredthsOfADegree:
-            guard bytes.count >= 5 else { return nil }
+            guard bytes.count == 5 else { return nil }
             let raw = UInt32(bytes[1])
                 | UInt32(bytes[2]) << 8
                 | UInt32(bytes[3]) << 16
                 | UInt32(bytes[4]) << 24
             degrees = Double(raw) / 100
         case .wholeDegrees:
-            guard bytes.count >= 3 else { return nil }
+            guard bytes.count == 3 else { return nil }
             degrees = Double(UInt16(bytes[1]) | UInt16(bytes[2]) << 8)
         }
 
@@ -100,6 +101,7 @@ public final class LidAngleSensor {
     private func open() {
         let manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
         let matching: [String: Any] = [
+            kIOHIDVendorIDKey: 0x05AC,
             kIOHIDDeviceUsagePageKey: 0x20,
             kIOHIDDeviceUsageKey: 0x8A,
         ]
@@ -112,17 +114,17 @@ public final class LidAngleSensor {
 
         guard let devices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice> else { return }
         for candidate in devices {
-            device = candidate
-            if let bytes = read(reportID: 7), bytes.count >= 5 {
-                resolution = .hundredthsOfADegree
-                return
+            guard (IOHIDDeviceGetProperty(candidate, "Built-In" as CFString) as? NSNumber)?.boolValue == true else {
+                continue
             }
-            if let bytes = read(reportID: 1), bytes.count >= 3 {
-                resolution = .wholeDegrees
-                return
+            device = candidate
+            for format in [Resolution.hundredthsOfADegree, .wholeDegrees] {
+                resolution = format
+                if angle() != nil { return }
             }
         }
         device = nil
+        resolution = nil
     }
 
     private func read(reportID: Int) -> [UInt8]? {

--- a/Sources/MacDuo/DepthOverlay.swift
+++ b/Sources/MacDuo/DepthOverlay.swift
@@ -157,6 +157,7 @@ final class DepthOverlay {
         fadeIn: TimeInterval
     ) -> Bool {
         dismiss(animated: false)
+        guard let displayID = screen.displayID, displayID == NSScreen.builtIn?.displayID else { return false }
         guard warmUp(), let renderer else { return false }
         self.startAngle = startAngle
         self.tuning = tuning
@@ -197,6 +198,7 @@ final class DepthOverlay {
         fadeIn: TimeInterval
     ) {
         dismiss(animated: false)
+        guard let displayID = screen.displayID, displayID == NSScreen.builtIn?.displayID else { return }
         guard warmUp(), let renderer else { return }
         self.startAngle = startAngle
         self.tuning = tuning

--- a/Sources/MacDuo/LidController.swift
+++ b/Sources/MacDuo/LidController.swift
@@ -272,7 +272,7 @@ final class LidController: ObservableObject {
     /// angle for release and keeps a lid held below the angle showing, unless
     /// the timeout ends it first.
     private func wantsEffect(angle: Double) -> Bool {
-        guard preferences.isEnabled else { return false }
+        guard preferences.isEnabled, NSScreen.builtIn != nil else { return false }
         if preferences.isTimeoutEnabled != wasTimeoutEnabled {
             timeoutReferenceAngle = nil
             timeoutAwaitingRelease = false


### PR DESCRIPTION
Original code may match an external Apple Studio Display and gives 0 degree readings