### PR TITLE
ci: validate pull request builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build universal app
+    runs-on: macos-26
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Build app bundle
+        run: ./build.sh --universal
+
+      - name: Validate artifacts
+        run: |
+          set -euo pipefail
+          APP_PATH='build/Mac Duo.app'
+          plutil -lint "$APP_PATH/Contents/Info.plist"
+          lipo "$APP_PATH/Contents/MacOS/MacDuo" -verify_arch arm64 x86_64
+          lipo build/lidprobe -verify_arch arm64 x86_64
+          codesign --verify --strict --all-architectures "$APP_PATH"
+          test -f "$APP_PATH/Contents/Resources/LICENSE"
+          test -f "$APP_PATH/Contents/Resources/NOTICE"


### PR DESCRIPTION
## Summary

- add a read-only CI workflow for pull requests and manual runs
- build the same universal app bundle as the release workflow with `./build.sh --universal`
- verify arm64 and x86_64 slices for both Mac Duo and `lidprobe`
- validate the bundle plist, ad-hoc signature, and packaged license files
- pin the checkout action to its immutable v4 commit and rely on the runner's default Xcode

## Why

The release workflow only runs after changes reach `main`, so contributions currently receive no build or packaging signal before merge. This workflow uses `contents: read`, does not receive release secrets, cancels superseded runs, and has a 15-minute timeout. It also prints the selected Xcode and Swift versions without adding a third-party toolchain-selection action.

## Validation

- completed a local universal build
- verified both architectures in the app and probe binaries
- validated the plist, signature, LICENSE, and NOTICE checks
- verified the pinned checkout SHA resolves to the official `actions/checkout` v4 ref
- checked the workflow YAML and ran `git diff --check`

The x86_64 validation proves that the Intel slices compile and link; it is not an Intel runtime test.

## Bootstrap note

The current fork run is marked `action_required` with no jobs because GitHub requires maintainer approval before running a first-time contributor's workflow. Once this workflow is on the default branch, later pull requests can receive the build signal normally.
