### PR TITLE
fix: apply Live rendering changes during active effects

### DIFF
--- a/Sources/MacDuo/LidController.swift
+++ b/Sources/MacDuo/LidController.swift
@@ -24,6 +24,11 @@ final class LidController: ObservableObject {
 
     let snapshotter = ScreenSnapshotter()
 
+    /// The picture source selected for the current effect run.
+    private var isPresentingLivePicture = false
+    /// Invalidates screenshot continuations from an earlier run or source.
+    private var pictureGeneration: UInt64 = 0
+
     private let preferences: Preferences
     private let sensor = LidAngleSensor()
     private let overlay = DepthOverlay()
@@ -145,9 +150,7 @@ final class LidController: ObservableObject {
     }
 
     private func stopEffectAndCapture() {
-        pictureTask?.cancel()
-        pictureTask = nil
-        isCapturePending = false
+        invalidatePictureRequests()
         stopDisplayLink()
         overlay.dismiss(animated: false)
         snapshotter.stop()
@@ -270,6 +273,10 @@ final class LidController: ObservableObject {
             setActive(wanted)
             return
         }
+        if isActive, isPresentingLivePicture != preferences.isLivePicture {
+            switchPictureSource()
+            return
+        }
         if isActive {
             if !overlay.isVisible, !isCapturePending { presentPicture() }
             // A visible overlay with no link would sit at its first frame.
@@ -346,11 +353,13 @@ final class LidController: ObservableObject {
 
     private func setActive(_ active: Bool) {
         isActive = active
+        invalidatePictureRequests()
         if active {
             startedAt = CACurrentMediaTime()
             visualAngle.reset(to: rawAngle)
             snapshotter.endPrewarm()
             setPollInterval(Self.activePollInterval)
+            isPresentingLivePicture = preferences.isLivePicture
             presentPicture()
         } else {
             stopDisplayLink()
@@ -367,7 +376,7 @@ final class LidController: ObservableObject {
     /// already running counts as that wait.
     private func presentPicture() {
         guard preferences.isEnabled, !isSuspended, isActive else { return }
-        if preferences.isLivePicture, let screen = NSScreen.builtIn,
+        if isPresentingLivePicture, let screen = NSScreen.builtIn,
            overlay.showLive(
                on: screen,
                startAngle: preferences.thresholdAngle,
@@ -396,12 +405,16 @@ final class LidController: ObservableObject {
             show(image: image, on: screen)
             return
         }
+        let generation = pictureGeneration
+        let expectedLivePicture = isPresentingLivePicture
         isCapturePending = true
         pictureTask?.cancel()
         pictureTask = Task { [weak self] in
             guard let self, !Task.isCancelled else { return }
             await self.snapshotter.captureOnce()
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled,
+                  generation == self.pictureGeneration,
+                  expectedLivePicture == self.isPresentingLivePicture else { return }
             self.pictureTask = nil
             self.isCapturePending = false
             Diagnostics.lid.notice(
@@ -417,16 +430,35 @@ final class LidController: ObservableObject {
         }
     }
 
+    /// Applies a picture-source setting change to the effect already on screen.
+    private func switchPictureSource() {
+        isPresentingLivePicture = preferences.isLivePicture
+        invalidatePictureRequests()
+        Diagnostics.lid.notice(
+            "switch picture source to \(self.isPresentingLivePicture ? "live" : "still", privacy: .public)"
+        )
+        stopDisplayLink()
+        overlay.dismiss(animated: false)
+        streamer.stop()
+        overlay.discardLive()
+        if isPresentingLivePicture { streamer.start() }
+        presentPicture()
+    }
+
     /// Takes one screenshot to start a live overlay that has nothing to show
     /// yet. A stream frame that lands first makes it unnecessary.
     private func requestSeed() {
+        let generation = pictureGeneration
+        let expectedLivePicture = isPresentingLivePicture
         isCapturePending = true
         let started = CACurrentMediaTime()
         pictureTask?.cancel()
         pictureTask = Task { [weak self] in
             guard let self, !Task.isCancelled else { return }
             await self.snapshotter.captureOnce()
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled,
+                  generation == self.pictureGeneration,
+                  expectedLivePicture == self.isPresentingLivePicture else { return }
             self.pictureTask = nil
             self.isCapturePending = false
             Diagnostics.lid.notice(
@@ -440,6 +472,13 @@ final class LidController: ObservableObject {
                   let image = self.snapshotter.latestImage else { return }
             self.overlay.seed(image: image)
         }
+    }
+
+    private func invalidatePictureRequests() {
+        pictureTask?.cancel()
+        pictureTask = nil
+        pictureGeneration &+= 1
+        isCapturePending = false
     }
 
     private func show(image: CGImage, on screen: NSScreen) {

--- a/Sources/MacDuo/ScreenStreamer.swift
+++ b/Sources/MacDuo/ScreenStreamer.swift
@@ -77,6 +77,8 @@ final class ScreenStreamer {
     private var stream: SCStream?
     private var receiver: Receiver?
     private var startTask: Task<Void, Never>?
+    /// Identifies the only start operation that may publish stream state.
+    private var startGeneration: UInt64 = 0
     /// Enumerating every on screen window costs about 70 ms, so the filter is
     /// kept between runs and rebuilt only when the display changes.
     private var filter: SCContentFilter?
@@ -99,17 +101,21 @@ final class ScreenStreamer {
     func start() {
         guard !isStarted, startTask == nil, device != nil else { return }
         guard let target = NSScreen.builtIn, let displayID = target.displayID else { return }
+        startGeneration &+= 1
+        let generation = startGeneration
         screen = target
         isStarted = true
         startTask = Task { [weak self] in
-            await self?.begin(displayID: displayID, on: target)
-            guard !Task.isCancelled else { return }
-            self?.startTask = nil
+            await self?.begin(displayID: displayID, on: target, generation: generation)
+            guard !Task.isCancelled, let self,
+                  generation == self.startGeneration else { return }
+            self.startTask = nil
         }
     }
 
     func stop() {
-        guard isStarted || stream != nil else { return }
+        guard isStarted || stream != nil || startTask != nil else { return }
+        startGeneration &+= 1
         isStarted = false
         startTask?.cancel()
         startTask = nil
@@ -127,7 +133,8 @@ final class ScreenStreamer {
     func warmFilter() async {
         guard let displayID = NSScreen.builtIn?.displayID else { return }
         guard filter == nil || filterDisplayID != displayID else { return }
-        await rebuildFilter(displayID: displayID)
+        let generation = startGeneration
+        await rebuildFilter(displayID: displayID, generation: generation)
     }
 
     /// Drops the cached filter, so the next start enumerates the windows again.
@@ -147,17 +154,22 @@ final class ScreenStreamer {
         return latest.frame
     }
 
-    private func begin(displayID: CGDirectDisplayID, on target: NSScreen) async {
-        guard !Task.isCancelled else { return }
+    private func begin(displayID: CGDirectDisplayID, on target: NSScreen, generation: UInt64) async {
+        guard !Task.isCancelled, generation == startGeneration, isStarted else { return }
         guard let device, let receiver = Receiver(device: device) else {
+            guard !Task.isCancelled, generation == startGeneration else { return }
             isStarted = false
             return
         }
         do {
             if filter == nil || filterDisplayID != displayID {
-                await rebuildFilter(displayID: displayID)
+                await rebuildFilter(displayID: displayID, generation: generation)
             }
-            guard !Task.isCancelled, isStarted, let activeFilter = filter else { return }
+            guard !Task.isCancelled, generation == startGeneration, isStarted else { return }
+            guard let activeFilter = filter else {
+                isStarted = false
+                return
+            }
 
             let configuration = SCStreamConfiguration()
             configuration.width = Int(activeFilter.contentRect.width * CGFloat(activeFilter.pointPixelScale))
@@ -177,7 +189,7 @@ final class ScreenStreamer {
             )
             let started = CFAbsoluteTimeGetCurrent()
             try await fresh.startCapture()
-            guard !Task.isCancelled, isStarted else {
+            guard !Task.isCancelled, generation == startGeneration, isStarted else {
                 try? await fresh.stopCapture()
                 return
             }
@@ -191,20 +203,20 @@ final class ScreenStreamer {
                 """
             )
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == startGeneration else { return }
             Diagnostics.geometry.error("stream failed: \(String(describing: error), privacy: .public)")
             invalidateFilter()
             isStarted = false
         }
     }
 
-    private func rebuildFilter(displayID: CGDirectDisplayID) async {
+    private func rebuildFilter(displayID: CGDirectDisplayID, generation: UInt64) async {
         do {
             let content = try await SCShareableContent.excludingDesktopWindows(
                 false,
                 onScreenWindowsOnly: true
             )
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == startGeneration else { return }
             guard let display = content.displays.first(where: { $0.displayID == displayID }) else {
                 invalidateFilter()
                 return
@@ -222,7 +234,7 @@ final class ScreenStreamer {
             )
             filterDisplayID = displayID
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == startGeneration else { return }
             Diagnostics.geometry.error("stream filter failed: \(String(describing: error), privacy: .public)")
             invalidateFilter()
         }


### PR DESCRIPTION
## Problem

`isLivePicture` was only consulted when `presentPicture()` ran. Once an overlay was visible, changing **Live rendering** did not select a new picture source:

- enabling it left the current held frame in place until the next lid cycle
- disabling it left the live stream capturing and updating the overlay

## Change

- remember which picture source was selected for the current effect
- reconcile that source with the preference during active polling
- when it changes, stop the old display link and stream, discard the old live texture, and present the effect again with the selected source
- explicitly start the stream when switching from a still picture to live rendering
- invalidate older screenshot continuations so a rapid toggle cannot clear or present over the new source
- generation-gate asynchronous stream setup so a stopped start cannot publish into a newer start

The existing screenshot and live-seeding paths are reused, so behavior outside a mid-effect setting change is unchanged.

## Lifecycle edges

- repeated `live -> still -> live` changes converge on the latest setting
- stopping or sleeping invalidates pending presentation work
- an older stream setup cannot clear a newer `startTask`, install its receiver, or invalidate the newer filter
- failed setup remains retryable on the next normal start

The capture-cancellation behavior now on `main` is retained: disabling, sleeping, or stopping the app cancels the underlying screenshot. A normal animated effect end still only discards its cache, so this PR limits its additional guarantee to presentation state rather than changing `ScreenSnapshotter` ownership.

## Validation

- debug build with Swift warnings treated as errors
- release build with Swift warnings treated as errors
- `git diff --check`
- exercised the generation guards against rapid source changes and stop/start ordering in code review
- retained the cancellation guards from PR #3 while resolving the rebase onto current `main`

The change has not been exercised during a physical lid-close cycle.

## Coordination

PR #16 also changes stream filter rebuilding, so the two PRs have a small textual conflict in `ScreenStreamer`. The tested resolution keeps this PR's cancellation and start-generation guards together with #16's fail-closed exclusion helper and post-rebuild filter readiness check.
