### PR TITLE
fix: fail closed when capture filters are unsafe

### DIFF
--- a/Sources/MacDuo/CaptureFilterSafety.swift
+++ b/Sources/MacDuo/CaptureFilterSafety.swift
@@ -1,0 +1,30 @@
+import AppKit
+import ScreenCaptureKit
+
+/// Resolves the applications a display capture must leave out to avoid
+/// feeding Mac Duo's own windows back into its picture.
+enum CaptureFilterSafety {
+    /// `nil` means the current process is not in the shareable-content list,
+    /// so no filter can yet prove that it excludes this instance.
+    static func excludedApplications(
+        in content: SCShareableContent
+    ) -> [SCRunningApplication]? {
+        let processID = NSRunningApplication.current.processIdentifier
+        guard let currentApplication = content.applications.first(where: {
+            $0.processID == processID
+        }) else {
+            return nil
+        }
+
+        // PID confirms this exact process is excluded. When ScreenCaptureKit
+        // reports a bundle ID, also exclude other Mac Duo instances: their
+        // overlays can feed back just like this one's.
+        let bundleID: String? = currentApplication.bundleIdentifier
+        guard let bundleID, !bundleID.isEmpty else {
+            return [currentApplication]
+        }
+        return content.applications.filter {
+            $0.processID == processID || $0.bundleIdentifier == bundleID
+        }
+    }
+}

--- a/Sources/MacDuo/ScreenSnapshotter.swift
+++ b/Sources/MacDuo/ScreenSnapshotter.swift
@@ -154,11 +154,18 @@ final class ScreenSnapshotter {
             )
             guard let display = content.displays.first(where: { $0.displayID == displayID }) else {
                 filter = nil
+                filterDisplayID = nil
                 return
             }
             // Exclude ourselves, or a lingering overlay lands in the next snapshot.
-            let bundleID = Bundle.main.bundleIdentifier
-            let ownApplications = content.applications.filter { $0.bundleIdentifier == bundleID }
+            guard let ownApplications = CaptureFilterSafety.excludedApplications(in: content) else {
+                Diagnostics.geometry.error(
+                    "snapshot cannot exclude this app: its presence window is not shareable yet"
+                )
+                filter = nil
+                filterDisplayID = nil
+                return
+            }
             filter = SCContentFilter(
                 display: display,
                 excludingApplications: ownApplications,

--- a/Sources/MacDuo/ScreenStreamer.swift
+++ b/Sources/MacDuo/ScreenStreamer.swift
@@ -156,6 +156,10 @@ final class ScreenStreamer {
         do {
             if filter == nil || filterDisplayID != displayID {
                 await rebuildFilter(displayID: displayID)
+                guard filter != nil, filterDisplayID == displayID else {
+                    if !Task.isCancelled { isStarted = false }
+                    return
+                }
             }
             guard !Task.isCancelled, isStarted, let activeFilter = filter else { return }
 
@@ -210,10 +214,12 @@ final class ScreenStreamer {
                 return
             }
             // Exclude ourselves, or the overlay feeds back into its own picture.
-            let bundleID = Bundle.main.bundleIdentifier
-            let ownApplications = content.applications.filter { $0.bundleIdentifier == bundleID }
-            if ownApplications.isEmpty {
-                Diagnostics.geometry.error("stream cannot exclude this app: it owns no window yet")
+            guard let ownApplications = CaptureFilterSafety.excludedApplications(in: content) else {
+                Diagnostics.geometry.error(
+                    "stream cannot exclude this app: its presence window is not shareable yet"
+                )
+                invalidateFilter()
+                return
             }
             filter = SCContentFilter(
                 display: display,


### PR DESCRIPTION
## Problem

Both capture paths built their self-exclusion list by comparing bundle identifiers. If ScreenCaptureKit had not listed Mac Duo yet, or reported no bundle identifier, that list could be empty and capture would continue. A screenshot could then contain a lingering overlay, while a live stream could feed the overlay back into itself.

## Change

- centralize self-exclusion selection for screenshots and live streams
- require the current process ID to appear in `SCShareableContent` before constructing a filter
- exclude this exact process even when its bundle identifier is missing
- when a bundle identifier is available, also exclude other Mac Duo instances
- clear cached filter identity on every failure
- leave a failed stream start retryable instead of keeping `isStarted` stuck

This intentionally fails closed: when ScreenCaptureKit cannot prove that the current process is excluded, Mac Duo skips that capture instead of risking recursive or stale overlay content. A transient miss at the trigger boundary can make that lid cycle fall back to a still seed; the next normal cycle retries.

## Validation

- debug build with Swift warnings treated as errors
- release build with Swift warnings treated as errors
- universal arm64/x86_64 app build
- `git diff --check`
- based on current `main`, retaining the capture-cancellation guards merged in PR #3
- manually combined with PR #15, followed by debug and release warnings-as-errors builds

## Coordination

PR #15 also changes the asynchronous stream-start and filter-rebuild lifecycle, so the two PRs have a small textual conflict in `ScreenStreamer`. The tested resolution keeps #15's start-generation checks together with this PR's fail-closed exclusion helper and post-rebuild filter readiness check.
