### PR TITLE
perf: update the menu bar angle only when needed

### DIFF
--- a/Sources/MacDuo/StatusItemController.swift
+++ b/Sources/MacDuo/StatusItemController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 /// The menu bar item and the settings popover.
@@ -9,7 +10,8 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private let popover = NSPopover()
     private let preferences: Preferences
     private let controller: LidController
-    private var titleTimer: Timer?
+    private var showsAngleSubscription: AnyCancellable?
+    private var angleSubscription: AnyCancellable?
     private var barWindowMoved: NSObjectProtocol?
 
     init(controller: LidController, preferences: Preferences) {
@@ -43,17 +45,17 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         hostingController.sizingOptions = [.preferredContentSize]
         popover.contentViewController = hostingController
 
-        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated { self?.refreshTitle() }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        titleTimer = timer
-        refreshTitle()
+        showsAngleSubscription = preferences.$showsAngleInMenuBar
+            .removeDuplicates()
+            .sink { [weak self] showsAngle in
+                self?.setShowsAngle(showsAngle)
+            }
         watchBarWindow()
     }
 
     deinit {
-        titleTimer?.invalidate()
+        showsAngleSubscription?.cancel()
+        angleSubscription?.cancel()
         if let barWindowMoved {
             NotificationCenter.default.removeObserver(barWindowMoved)
         }
@@ -99,12 +101,28 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         popover.show(relativeTo: .zero, of: button, preferredEdge: .minY)
     }
 
-    private func refreshTitle() {
-        guard let button = statusItem.button else { return }
-        if preferences.showsAngleInMenuBar {
-            button.title = String(format: " %.0f°", controller.currentAngle)
-        } else if !button.title.isEmpty {
-            button.title = ""
+    private func setShowsAngle(_ showsAngle: Bool) {
+        angleSubscription?.cancel()
+        angleSubscription = nil
+
+        guard showsAngle else {
+            statusItem.button?.title = ""
+            return
         }
+        // Throttle delivers its first value asynchronously, so show it now;
+        // the 250 ms window preserves the former timer's 4 Hz ceiling.
+        statusItem.button?.title = Self.angleTitle(controller.currentAngle)
+        angleSubscription = controller.$currentAngle
+            .map(Self.angleTitle)
+            .removeDuplicates()
+            .throttle(for: .milliseconds(250), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] title in
+                guard self?.statusItem.button?.title != title else { return }
+                self?.statusItem.button?.title = title
+            }
+    }
+
+    private static func angleTitle(_ angle: Double) -> String {
+        String(format: " %.0f°", angle)
     }
 }


### PR DESCRIPTION
## Problem

`StatusItemController` ran a 250 ms timer for its entire lifetime, even when **Show angle in menu bar** was off (the default). Most timer firings therefore read the angle and touched no UI.

## Change

- observe the visibility preference instead of polling it
- subscribe to angle changes only while the title is enabled
- format and de-duplicate whole-degree titles before writing AppKit state
- preserve the previous 4 Hz update ceiling with a latest-value throttle
- publish the initial title immediately, then cancel and clear it immediately when disabled

The lid sensor's own polling is unchanged; this only removes hidden status-title wakeups and redundant title assignments.

## Edge cases

- the persisted enabled state produces a title during controller initialization
- repeated on/off toggles replace, rather than accumulate, subscriptions
- cancellation drops any throttled trailing value before the title is cleared
- weak captures and explicit cancellation avoid retaining the status controller

## Validation

- debug build with Swift warnings treated as errors
- release build with Swift warnings treated as errors
- `git diff --check`
- verified clean automatic merges with PRs #8, #11, #14, #15, and #16
- PRs #6 and #9 already conflict with current `main`; this change adds no overlapping files
- verified with a small Combine timing harness that the explicit initial write is needed and cancellation suppresses a queued latest value
