### PR TITLE
fix: Simplified Chinese lookup and lid-driven blur/dim

### DIFF
--- a/Sources/MacDuo/BlurGradient.swift
+++ b/Sources/MacDuo/BlurGradient.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// How far out of focus the picture is at a given height, and how much light
-/// it has lost. Height is 0 at the hinge edge and 1 at the far edge.
+/// How far out of focus the picture is, and how much light it has lost, as
+/// the lid travels. Spatial falloff lives in the shader so blur and dim
+/// follow the same receded-depth pose.
 struct BlurGradient {
 
     /// Exponent on the closing travel. Values above 1 start slowly.

--- a/Sources/MacDuo/DepthOverlay.swift
+++ b/Sources/MacDuo/DepthOverlay.swift
@@ -20,20 +20,35 @@ struct DepthGeometry {
     /// Past 90 degrees the picture turns its face away from the glass.
     var maxSeparationDegrees: Double = 88
 
-    /// Bottom-left, bottom-right, top-right, top-left.
-    func corners(
+    /// One pose of the receding picture, shared by the projection and the
+    /// lighting so dimming follows the same lid travel as the warp.
+    struct Pose {
+        /// Bottom-left, bottom-right, top-right, top-left.
+        var corners: [CGPoint]
+        var sinSeparation: Double
+        var cosSeparation: Double
+        /// Eye position in glass coordinates, in points. Hinge at the origin,
+        /// +Y along the glass, +Z away from the glass toward the far side of
+        /// the picture's tilt.
+        var eyeAlong: Double
+        var eyeDepth: Double
+    }
+
+    func pose(
         startAngle: Double,
         currentAngle: Double,
         viewingDistanceRatio: Double,
         recession: Double,
         screenSize: CGSize
-    ) -> [CGPoint] {
+    ) -> Pose {
         let width = Double(screenSize.width)
         let height = Double(screenSize.height)
         let start = startAngle * .pi / 180
         let current = currentAngle * .pi / 180
         let travel = max(startAngle - currentAngle, 0)
         let separation = min(recession * travel, maxSeparationDegrees) * .pi / 180
+        let sinSeparation = sin(separation)
+        let cosSeparation = cos(separation)
 
         // The eye in world axes, hinge at the origin.
         let reach = height * viewingDistanceRatio + height / 2 * cos(start)
@@ -45,13 +60,19 @@ struct DepthGeometry {
 
         let half = width / 2
         func project(_ x: Double, _ y: Double) -> CGPoint {
-            let scale = depth / (depth + y * sin(separation))
+            let scale = depth / (depth + y * sinSeparation)
             return CGPoint(
                 x: half + (x - half) * scale,
-                y: along + (y * cos(separation) - along) * scale
+                y: along + (y * cosSeparation - along) * scale
             )
         }
-        return [project(0, 0), project(width, 0), project(width, height), project(0, height)]
+        return Pose(
+            corners: [project(0, 0), project(width, 0), project(width, height), project(0, height)],
+            sinSeparation: sinSeparation,
+            cosSeparation: cosSeparation,
+            eyeAlong: along,
+            eyeDepth: depth
+        )
     }
 }
 
@@ -270,21 +291,23 @@ final class DepthOverlay {
     func update(progress: Double, currentAngle: Double, tuning: DepthTuning) {
         guard let renderer, renderer.isReady else { return }
         self.tuning = tuning
+        let pose = geometry.pose(
+            startAngle: startAngle,
+            currentAngle: currentAngle,
+            viewingDistanceRatio: tuning.viewingDistance,
+            recession: tuning.recession,
+            screenSize: screenSize
+        )
         renderer.render(
-            corners: geometry.corners(
-                startAngle: startAngle,
-                currentAngle: currentAngle,
-                viewingDistanceRatio: tuning.viewingDistance,
-                recession: tuning.recession,
-                screenSize: screenSize
-            ),
+            corners: pose.corners,
             blurStrength: gradient.blurStrength(progress: progress),
             dimStrength: gradient.dimStrength(progress: progress),
             hingeFloor: tuning.blurEvenness,
             dimHingeFloor: gradient.dimHingeFloor,
             dimReach: tuning.dimReach,
             maxBlurRadius: tuning.maxBlurRadius,
-            maxDim: tuning.maxDim
+            maxDim: tuning.maxDim,
+            pose: pose
         )
     }
 

--- a/Sources/MacDuo/DepthRenderer.swift
+++ b/Sources/MacDuo/DepthRenderer.swift
@@ -23,6 +23,7 @@ final class DepthRenderer {
         var paddedAndBlur: SIMD4<Float>
         var shape: SIMD4<Float>
         var light: SIMD4<Float>
+        var pose: SIMD4<Float>
     }
 
     /// One held picture, built off the main thread and adopted on it.
@@ -410,7 +411,8 @@ final class DepthRenderer {
         dimHingeFloor: Double,
         dimReach: Double,
         maxBlurRadius: Double,
-        maxDim: Double
+        maxDim: Double,
+        pose: DepthGeometry.Pose
     ) {
         guard let commands = queue.makeCommandBuffer() else { return }
         absorbPending(into: commands)
@@ -444,7 +446,11 @@ final class DepthRenderer {
                 Float(maxBlurRadius * Double(pixelScale)), Float(blurStrength)
             ),
             shape: SIMD4(Float(hingeFloor), Float(maxDim), Float(pixelScale), maxLevel),
-            light: SIMD4(Float(dimHingeFloor), Float(dimStrength), Float(dimReach), 0)
+            light: SIMD4(Float(dimHingeFloor), Float(dimStrength), Float(dimReach), 0),
+            pose: SIMD4(
+                Float(pose.sinSeparation), Float(pose.cosSeparation),
+                Float(pose.eyeAlong), Float(pose.eyeDepth)
+            )
         )
 
         let pass = MTLRenderPassDescriptor()

--- a/Sources/MacDuo/DepthShaders.swift
+++ b/Sources/MacDuo/DepthShaders.swift
@@ -4,9 +4,9 @@ import Foundation
 ///
 /// Each screen pixel maps back into the picture through the inverse
 /// perspective, then takes one sample from a Gaussian pyramid at a level
-/// chosen by the blur wanted there. The texture already holds the picture on
-/// black, so the two blur together and the picture edge needs no special
-/// handling.
+/// chosen by the lid-driven blur at that point. The texture already holds
+/// the picture on black, so the two blur together and the picture edge
+/// needs no special handling.
 enum DepthShaders {
     static let source = """
     #include <metal_stdlib>
@@ -21,6 +21,7 @@ enum DepthShaders {
         float4 paddedAndBlur;    // padded size, max radius in pixels, blur strength
         float4 shape;            // blur floor, max dim, pixel scale, max level
         float4 light;            // dim floor, dim strength, dim reach, unused
+        float4 pose;             // sin sep, cos sep, eye along, eye depth
     };
 
     vertex float4 depthVertex(uint vertexID [[vertex_id]]) {
@@ -45,6 +46,10 @@ enum DepthShaders {
         float dimFloor = uniforms.light.x;
         float dimStrength = uniforms.light.y;
         float dimReach = uniforms.light.z;
+        float sinSep = uniforms.pose.x;
+        float cosSep = uniforms.pose.y;
+        float eyeAlong = uniforms.pose.z;
+        float eyeDepth = uniforms.pose.w;
 
         // Fragment coordinates are pixels with y down; the geometry is points
         // with y up.
@@ -65,15 +70,38 @@ enum DepthShaders {
         float2 texCoord = float2(unit.x, 1.0 - unit.y);
 
         float height = clamp(picturePoint.y / screenSize.y, 0.0, 1.0);
-        float blur = strength * (blurFloor + (1.0 - blurFloor) * height);
+
+        // Receded depth behind the glass, in screen heights. Grows as the lid
+        // closes and toward the far edge. Blur and dim both read this, so they
+        // travel together instead of painting a 2D height band.
+        float behind = height * max(sinSep, 0.0);
+        float3 world = float3(picturePoint.x, picturePoint.y * cosSep, picturePoint.y * sinSep);
+        float3 eye = float3(screenSize.x * 0.5, eyeAlong, eyeDepth);
+        float3 toEye = eye - world;
+        float dist = length(toEye);
+        float3 normal = float3(0.0, -sinSep, cosSep);
+        float ndotv = saturate(dot(normal, toEye / max(dist, 1e-4)));
+        float facingFade = pow(1.0 - ndotv, 1.35);
+        float depthFalloff = 1.0 - exp(-behind / 0.55 * 2.2);
+
+        // blurFloor (模糊范围) still means evenness: 0 keeps the hinge sharp,
+        // 1 blurs the whole picture. The falloff itself follows the lid.
+        float concentrated = pow(max(depthFalloff, 0.0), mix(1.8, 1.0, blurFloor));
+        float blurSpatial = saturate(
+            mix(concentrated, 1.0, blurFloor) + facingFade * mix(0.12, 0.28, blurFloor)
+        );
+        float blur = strength * blurSpatial;
         // Naming this `level` would shadow Metal's level() selector.
         float mipLevel = clamp(log2(max(blur * maxRadius, 1.0)), 0.0, maxLevel);
 
         float4 colour = picture.sample(linearSampler, texCoord, level(mipLevel));
-        // smoothstep rather than a clamped ratio, so the height where the
-        // dimming reaches full strength leaves no visible edge.
-        float spread = smoothstep(0.0, max(dimReach, 0.02), height);
-        float fade = dimStrength * (dimFloor + (1.0 - dimFloor) * spread);
+
+        // dimReach scales how much tilt/height is needed to go dark, so the
+        // shadow grows down from the top while the lid travels.
+        float depthScale = mix(0.25, 1.35, saturate(dimReach));
+        float depthFade = 1.0 - exp(-behind / max(depthScale, 0.05) * 2.2);
+        float spatial = saturate(depthFade * 0.85 + facingFade * 0.35);
+        float fade = dimStrength * (dimFloor + (1.0 - dimFloor) * spatial);
         // The sample is linear light. Raising the factor to 2.2 keeps the
         // dimming setting a fraction of the encoded brightness.
         colour.rgb *= pow(1.0 - maxDim * fade, 2.2);

--- a/Sources/MacDuo/Preferences.swift
+++ b/Sources/MacDuo/Preferences.swift
@@ -85,14 +85,15 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(recession, forKey: Key.recession) }
     }
 
-    /// Blur at the hinge edge as a fraction of the blur at the far edge. One
-    /// blurs the whole picture by the same amount.
+    /// How evenly the lid-driven blur covers the picture. Zero keeps the
+    /// hinge sharp and blurs the receding far edge; one blurs everything.
     @Published var blurEvenness: Double {
         didSet { defaults.set(blurEvenness, forKey: Key.blurEvenness) }
     }
 
-    /// Height at which the dimming reaches full strength, as a fraction of
-    /// the screen height.
+    /// How quickly darkness grows from the far edge toward the hinge as the
+    /// lid closes. Lower covers more of the picture; it is no longer a hard
+    /// screen-height cutoff.
     @Published var dimReach: Double {
         didSet { defaults.set(dimReach, forKey: Key.dimReach) }
     }

--- a/Sources/MacDuo/Resources/en.lproj/Localizable.strings
+++ b/Sources/MacDuo/Resources/en.lproj/Localizable.strings
@@ -16,11 +16,11 @@
 "Blur" = "Blur";
 "Blur radius at the far edge." = "Blur radius at the far edge.";
 "Blur spread" = "Blur spread";
-"0 blurs the far edge only, 100 the whole picture." = "0 blurs the far edge only, 100 the whole picture.";
+"0 blurs the far edge only, 100 the whole picture." = "Blur grows down from the far edge as the lid closes. 0 keeps the hinge sharp; 100 blurs the whole picture.";
 "Dimming" = "Dimming";
 "How dark the far edge goes." = "How dark the far edge goes.";
 "Dimming spread" = "Dimming spread";
-"Everything above this height goes fully dark." = "Everything above this height goes fully dark.";
+"Everything above this height goes fully dark." = "How quickly darkness grows down from the far edge as the lid closes. Lower covers more of the screen; higher keeps it near the top.";
 "Perspective" = "Perspective";
 "Lean back" = "Lean back";
 "Degrees of lean per degree of closing. 1 holds it still." = "Degrees of lean per degree of closing. 1 holds it still.";

--- a/Sources/MacDuo/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/MacDuo/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,11 +16,11 @@
 "Blur" = "模糊强度";
 "Blur radius at the far edge." = "画面远端边缘的模糊半径。";
 "Blur spread" = "模糊范围";
-"0 blurs the far edge only, 100 the whole picture." = "0 仅模糊远端边缘，100 则模糊整个画面。";
+"0 blurs the far edge only, 100 the whole picture." = "合盖时模糊从远端往下长。0 只糊后倾的上沿，100 则整幅一起糊。";
 "Dimming" = "变暗强度";
 "How dark the far edge goes." = "画面远端边缘的变暗程度。";
 "Dimming spread" = "变暗范围";
-"Everything above this height goes fully dark." = "此高度以上的画面达到最大变暗强度。";
+"Everything above this height goes fully dark." = "合盖时暗部从远端往转轴延伸的速度。调低则覆盖更大，调高则主要暗在上沿。";
 "Perspective" = "透视";
 "Lean back" = "后倾幅度";
 "Degrees of lean per degree of closing. 1 holds it still." = "每合上 1° 时画面的后倾角度。设为 1 时，画面在空间中保持不动。";

--- a/Sources/MacDuo/SettingsLanguage.swift
+++ b/Sources/MacDuo/SettingsLanguage.swift
@@ -6,9 +6,30 @@ enum SettingsLanguage: String {
     case chinese = "zh-Hans"
 
     static var preferred: Self {
-        Bundle.preferredLocalizations(from: ["en", "zh-Hans"])
-            .first == "zh-Hans" ? .chinese : .english
+        Bundle.preferredLocalizations(from: available.map(\.rawValue))
+            .first
+            .flatMap(Self.init(rawValue:)) ?? .english
     }
+
+    static let available: [SettingsLanguage] = [.english, .chinese]
+
+    func localized(_ key: String) -> String {
+        Self.table(for: rawValue)[key] ?? key
+    }
+
+    /// `.lproj` directories are not bundles. Wrapping one in `Bundle(path:)`
+    /// and calling `localizedString` looks for a nested `*.lproj` inside it,
+    /// misses the strings, and returns the English key. `zh-Hans` must also
+    /// keep its canonical case — lowercasing it to `zh-hans` fails Bundle's
+    /// localization lookup.
+    private static func table(for localization: String) -> [String: String] {
+        if let cached = cachedTables[localization] { return cached }
+        let loaded = loadTable(for: localization)
+        cachedTables[localization] = loaded
+        return loaded
+    }
+
+    private static var cachedTables: [String: [String: String]] = [:]
 
     // Packaged apps keep resources in Contents/Resources; SwiftPM's generated
     // accessor only searches the app root and the original build directory.
@@ -18,13 +39,33 @@ enum SettingsLanguage: String {
         return Bundle.module
     }
 
-    private var bundle: Bundle {
-        guard let path = Self.resources.path(forResource: rawValue.lowercased(), ofType: "lproj"),
-              let bundle = Bundle(path: path) else { return Self.resources }
-        return bundle
+    private static func loadTable(for localization: String) -> [String: String] {
+        if let path = resources.path(
+            forResource: "Localizable",
+            ofType: "strings",
+            inDirectory: nil,
+            forLocalization: localization
+        ), let table = dictionary(at: URL(fileURLWithPath: path)) {
+            return table
+        }
+
+        let bundleURL = resources.bundleURL
+        let candidates = [
+            bundleURL.appendingPathComponent("Contents/Resources/\(localization).lproj/Localizable.strings"),
+            bundleURL.appendingPathComponent("\(localization).lproj/Localizable.strings"),
+            bundleURL.appendingPathComponent("Resources/\(localization).lproj/Localizable.strings"),
+        ]
+        for url in candidates {
+            if let table = dictionary(at: url) { return table }
+        }
+        return [:]
     }
 
-    func localized(_ key: String) -> String {
-        bundle.localizedString(forKey: key, value: key, table: nil)
+    private static func dictionary(at url: URL) -> [String: String]? {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let table = NSDictionary(contentsOf: url) as? [String: String],
+              !table.isEmpty
+        else { return nil }
+        return table
     }
 }

--- a/Sources/MacDuo/SettingsView.swift
+++ b/Sources/MacDuo/SettingsView.swift
@@ -65,6 +65,7 @@ struct SettingsView: View {
                 .padding(.bottom, 12)
         }
         .frame(width: Self.width)
+        .id(language)
         .onAppear { hasScreenPermission = CGPreflightScreenCaptureAccess() }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             hasScreenPermission = CGPreflightScreenCaptureAccess()


### PR DESCRIPTION
## Summary
- Load `zh-Hans` strings from the resource bundle instead of wrapping the `.lproj` as a `Bundle` (which fell back to the English key).
- Drive blur and dimming from the same receded-depth lid pose so they grow as the lid closes, instead of freezing at a screen-height cutoff.

## Test plan
- [ ] Packaged app: set Language to 简体中文 and confirm the settings panel is Chinese (not English keys).
- [ ] Switch Language between System / English / 简体中文 without restarting.
- [ ] Close the lid past the start angle: darkening and blur should start at the far edge and grow toward the hinge, not stop at a fixed band.
- [ ] Move 变暗范围 / 模糊范围 and confirm they still change coverage, without a hard height clip.