### PR TITLE
fix: scope the development app restart

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ echo "built ${BUNDLE}"
 codesign -dv "$BUNDLE" 2>&1 | grep -E "Identifier|TeamIdentifier|Signature" || true
 
 if "$RUN_APP"; then
-  pkill -x MacDuo 2>/dev/null || true
+  pkill -f -x "$PWD/$BUNDLE/Contents/MacOS/MacDuo" 2>/dev/null || true
   sleep 0.5
   open "$BUNDLE"
   echo "launched"


### PR DESCRIPTION
Fixes #24

`build.sh --run` used `pkill -x MacDuo`, which can terminate an installed `/Applications/Mac Duo.app` because development and production binaries share the same process name.

Scope the match to the current checkout's executable path so `--run` only replaces this development build.

Validation:
- `bash -n build.sh`
- confirmed the path match does not match the running `/Applications/Mac Duo.app`