### PR TITLE
fix: keep the release angle inside the hinge's reach

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,5 +24,11 @@ let package = Package(
             path: "Sources/lidprobe",
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+        .testTarget(
+            name: "LidAngleKitTests",
+            dependencies: ["LidAngleKit"],
+            path: "Tests/LidAngleKitTests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
     ]
 )

--- a/Sources/LidAngleKit/LidAngleRange.swift
+++ b/Sources/LidAngleKit/LidAngleRange.swift
@@ -1,0 +1,81 @@
+/// The band of lid angles the depth effect may work in on this Mac.
+///
+/// Hinges differ by model and nothing in the sensor reports the range, so the
+/// widest angle seen is remembered and every bound is derived from it. The
+/// property that matters: a release is only ever asked for at an angle the lid
+/// has already been observed to reach. A start angle sitting near the hinge
+/// stop therefore cannot leave the picture up for good.
+public struct LidAngleRange: Equatable, Sendable {
+
+    /// Widest angle the sensor has reported, or zero before the first reading.
+    public var observedMax: Double
+
+    /// Degrees above the start angle at which an active effect lets go. Keeps
+    /// the picture from flickering around the boundary.
+    public var hysteresis: Double
+
+    /// Degrees kept clear of `observedMax`, so letting go never asks for the
+    /// lid to be held against its hard stop.
+    public var reachMargin: Double
+
+    /// Stands in for the hinge until the first reading arrives.
+    public var assumedMax: Double
+
+    /// Lowest start angle offered.
+    public var minThreshold: Double
+
+    /// Narrowest span the start angle is allowed to offer, so a low
+    /// `observedMax` cannot collapse the control to a single value.
+    public var minSpan: Double
+
+    public init(
+        observedMax: Double,
+        hysteresis: Double,
+        reachMargin: Double = 1,
+        assumedMax: Double = 130,
+        minThreshold: Double = 5,
+        minSpan: Double = 5
+    ) {
+        self.observedMax = observedMax
+        self.hysteresis = hysteresis
+        self.reachMargin = reachMargin
+        self.assumedMax = assumedMax
+        self.minThreshold = minThreshold
+        self.minSpan = minSpan
+    }
+
+    /// The hinge maximum in use: measured once known, assumed before that.
+    public var knownMax: Double {
+        observedMax > 0 ? observedMax : assumedMax
+    }
+
+    /// Widest angle a release may be asked for. Anything past it is a release
+    /// the hinge cannot perform.
+    public var releaseCeiling: Double {
+        max(minThreshold, knownMax - reachMargin)
+    }
+
+    /// Highest start angle worth offering, so the release that follows from it
+    /// still lands inside `releaseCeiling`.
+    public var maxThreshold: Double {
+        max(minThreshold + minSpan, releaseCeiling - hysteresis)
+    }
+
+    /// The angle an active effect lets go at, with the hysteresis held inside
+    /// the reachable range.
+    public func releaseAngle(startingAt threshold: Double) -> Double {
+        min(threshold + hysteresis, releaseCeiling)
+    }
+
+    /// Pulls a start angle into the range the hinge can leave. Values from an
+    /// earlier version, or written straight to the plist, can sit above it.
+    public func clamped(threshold: Double) -> Double {
+        min(max(threshold, minThreshold), maxThreshold)
+    }
+
+    /// Whether a lid at `angle` can still let the effect go. False means the
+    /// configuration traps the picture on screen.
+    public func isReleasable(threshold: Double, reachableMax: Double) -> Bool {
+        releaseAngle(startingAt: threshold) <= reachableMax
+    }
+}

--- a/Sources/MacDuo/LidController.swift
+++ b/Sources/MacDuo/LidController.swift
@@ -252,6 +252,9 @@ final class LidController: ObservableObject {
                 )
             }
             consecutiveFailedReads = 0
+            // Only a real reading widens the known hinge range. A scripted
+            // preview must not teach the app an angle the lid cannot reach.
+            preferences.noteObserved(angle: read)
             angle = read
         }
 
@@ -285,7 +288,7 @@ final class LidController: ObservableObject {
         let threshold = preferences.thresholdAngle
         if isActive {
             guard CACurrentMediaTime() - startedAt > Self.minimumEffectDuration else { return true }
-            if angle >= threshold + preferences.hysteresis { return false }
+            if angle >= releaseAngle(for: threshold) { return false }
             if preferences.isTimeoutEnabled, isPastTimeout(angle: angle) {
                 timeoutAwaitingRelease = true
                 return false
@@ -301,6 +304,17 @@ final class LidController: ObservableObject {
         // A lid resting below the angle must not start by itself.
         let closing = CACurrentMediaTime() - lastMovedDownTime < Self.closingMemory
         return closing && predictedAngle() <= threshold
+    }
+
+    /// The angle an active effect lets go at.
+    ///
+    /// The hysteresis that keeps the picture from flickering at the boundary
+    /// is held inside the range the lid has been seen to reach, so a start
+    /// angle near the hinge stop cannot ask for an angle that does not exist.
+    /// Without this a threshold of 130 waits for 134 degrees on a hinge that
+    /// stops at 132, and the picture stays up for good.
+    private func releaseAngle(for threshold: Double) -> Double {
+        preferences.angleRange.releaseAngle(startingAt: threshold)
     }
 
     /// True once the angle has held within `timeoutMovementThreshold` of its
@@ -334,6 +348,13 @@ final class LidController: ObservableObject {
             return
         }
         if isActive {
+            // The pre-warm owns the stream, and it only runs while the lid is
+            // closing. An effect that starts after the lid has settled would
+            // otherwise keep the one seeded screenshot for as long as it is up,
+            // which reads as a frozen screen. Live rendering has to hold the
+            // stream for itself while the picture is on show. `start()` is a
+            // no-op once running.
+            if preferences.isLivePicture { streamer.start() }
             if !overlay.isVisible, !isCapturePending { presentPicture() }
             // A visible overlay with no link would sit at its first frame.
             if overlay.isVisible, displayLink == nil { startDisplayLink() }

--- a/Sources/MacDuo/Preferences.swift
+++ b/Sources/MacDuo/Preferences.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import LidAngleKit
 
 /// User settings, backed by `UserDefaults`.
 @MainActor
@@ -19,7 +20,11 @@ final class Preferences: ObservableObject {
         static let dimReach = "dimReach"
         static let showsAngleInMenuBar = "showsAngleInMenuBar"
         static let isLivePicture = "isLivePicture"
+        static let observedMaxAngle = "observedMaxAngle"
 
+        // `observedMaxAngle` is left out on purpose. It measures the hinge
+        // rather than stating a preference, and forgetting it would hand back
+        // a start angle the lid cannot open past.
         static let all = [
             isEnabled, isTimeoutEnabled, thresholdAngle, blurSpan, maxBlurRadius,
             maxDim, viewingDistance, recession, blurEvenness, dimReach,
@@ -29,7 +34,10 @@ final class Preferences: ObservableObject {
 
     private static let factory: [String: Any] = [
         Key.isEnabled: true,
-        Key.isTimeoutEnabled: false,
+        // On by default. It is the only release the lid can reach without
+        // opening all the way, and a user who needs it is by then looking at
+        // a picture that hides the panel holding the switch.
+        Key.isTimeoutEnabled: true,
         Key.thresholdAngle: 90.0,
         Key.blurSpan: 60.0,
         Key.maxBlurRadius: 135.0,
@@ -40,6 +48,7 @@ final class Preferences: ObservableObject {
         Key.dimReach: 0.5,
         Key.showsAngleInMenuBar: false,
         Key.isLivePicture: true,
+        Key.observedMaxAngle: 0.0,
     ]
 
     /// Master switch for the depth effect.
@@ -108,6 +117,13 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(isLivePicture, forKey: Key.isLivePicture) }
     }
 
+    /// Widest angle the sensor has reported on this Mac, or zero before the
+    /// first reading. Hinges differ by model, and nothing in the sensor
+    /// reports the range, so it is learned and remembered.
+    @Published private(set) var observedMaxAngle: Double {
+        didSet { defaults.set(observedMaxAngle, forKey: Key.observedMaxAngle) }
+    }
+
     /// Eye distance in screen heights, at the two ends of the perspective
     /// slider. The panel offers the strength, which runs the other way.
     static let farthestEye: Double = 6
@@ -128,6 +144,54 @@ final class Preferences: ObservableObject {
 
     /// Degrees above the threshold before the overlay is released.
     let hysteresis: Double = 4
+
+    /// Degrees kept clear of the widest angle seen, so letting go never asks
+    /// the lid to be pressed against its hard stop.
+    let reachMargin: Double = 1
+
+    /// A reading wider than this is sensor noise, not a wider hinge.
+    let plausibleMaxAngle: Double = 150
+
+    /// Lowest start angle the panel offers.
+    static let minThresholdAngle: Double = 5
+
+    /// Stands in for the hinge before the first reading arrives. The sensor
+    /// header puts a MacBook at roughly this much.
+    static let assumedMaxAngle: Double = 130
+
+    /// The reachable angle band, rebuilt from what the sensor has reported.
+    var angleRange: LidAngleRange {
+        LidAngleRange(
+            observedMax: observedMaxAngle,
+            hysteresis: hysteresis,
+            reachMargin: reachMargin,
+            assumedMax: Self.assumedMaxAngle,
+            minThreshold: Self.minThresholdAngle
+        )
+    }
+
+    /// Widest angle an active effect may be asked to release at. Anything
+    /// beyond it is a release the hinge cannot perform.
+    var releaseCeiling: Double { angleRange.releaseCeiling }
+
+    /// Highest start angle the panel offers, so the release that follows from
+    /// it stays inside `releaseCeiling`.
+    var maxThresholdAngle: Double { angleRange.maxThreshold }
+
+    /// Widens the known hinge range. Fed every sensor reading.
+    func noteObserved(angle: Double) {
+        guard angle > observedMaxAngle, angle <= plausibleMaxAngle else { return }
+        observedMaxAngle = angle
+    }
+
+    /// Pulls a stored start angle back into the range the hinge can leave.
+    /// Values from an earlier version, or written straight to the plist, can
+    /// sit above it.
+    func clampThresholdAngle() {
+        let bounded = angleRange.clamped(threshold: thresholdAngle)
+        guard bounded != thresholdAngle else { return }
+        thresholdAngle = bounded
+    }
 
     /// Settings from earlier versions, removed at launch.
     private static let retired = [
@@ -154,6 +218,8 @@ final class Preferences: ObservableObject {
         dimReach = defaults.double(forKey: Key.dimReach)
         showsAngleInMenuBar = defaults.bool(forKey: Key.showsAngleInMenuBar)
         isLivePicture = defaults.bool(forKey: Key.isLivePicture)
+        observedMaxAngle = defaults.double(forKey: Key.observedMaxAngle)
+        clampThresholdAngle()
     }
 
     func resetToDefaults() {
@@ -172,5 +238,6 @@ final class Preferences: ObservableObject {
         dimReach = defaults.double(forKey: Key.dimReach)
         showsAngleInMenuBar = defaults.bool(forKey: Key.showsAngleInMenuBar)
         isLivePicture = defaults.bool(forKey: Key.isLivePicture)
+        clampThresholdAngle()
     }
 }

--- a/Sources/MacDuo/SettingsView.swift
+++ b/Sources/MacDuo/SettingsView.swift
@@ -113,7 +113,8 @@ struct SettingsView: View {
                 help: localized("Ends the effect once the angle stops changing.")
             )
             slider(
-                localized("Start angle"), value: $preferences.thresholdAngle, in: 5...130, format: "%.0f°",
+                localized("Start angle"), value: $preferences.thresholdAngle,
+                in: Preferences.minThresholdAngle...preferences.maxThresholdAngle, format: "%.0f°",
                 help: localized("The effect starts at this angle.")
             )
             slider(

--- a/Tests/LidAngleKitTests/LidAngleRangeTests.swift
+++ b/Tests/LidAngleKitTests/LidAngleRangeTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+@testable import LidAngleKit
+
+/// The bug these cover: a start angle of 130 with a hysteresis of 4 waits for
+/// 134 degrees, and no MacBook hinge opens that far, so the picture never lets
+/// go. Every case below is stated against a hinge that stops somewhere real.
+final class LidAngleRangeTests: XCTestCase {
+
+    /// Hinge maxima measured on real machines, plus a narrow one to keep the
+    /// arithmetic honest.
+    private let hinges: [(name: String, max: Double)] = [
+        ("132 degree hinge", 132),
+        ("133 degree hinge", 133),
+        ("130.9 degree hinge", 130.9),
+        ("narrow hinge", 125),
+    ]
+
+    private func makeRange(observedMax: Double, hysteresis: Double = 4) -> LidAngleRange {
+        LidAngleRange(observedMax: observedMax, hysteresis: hysteresis)
+    }
+
+    // MARK: - The trap
+
+    func testHighestOfferedStartAngleStaysReleasableOnEveryHinge() {
+        for hinge in hinges {
+            let range = makeRange(observedMax: hinge.max)
+            let release = range.releaseAngle(startingAt: range.maxThreshold)
+            XCTAssertLessThanOrEqual(
+                release, hinge.max,
+                "\(hinge.name): release at \(release)° needs more than the \(hinge.max)° the hinge has"
+            )
+        }
+    }
+
+    func testStoredStartAngleOf130StaysReleasableOnEveryHinge() {
+        // A value written straight to the plist while the app runs skips the
+        // clamp, which is how this was first reproduced.
+        for hinge in hinges {
+            let release = makeRange(observedMax: hinge.max).releaseAngle(startingAt: 130)
+            XCTAssertLessThanOrEqual(
+                release, hinge.max,
+                "\(hinge.name): a stored 130 still asks for \(release)°"
+            )
+        }
+    }
+
+    func testCeilingIsWhatMakesTheTrapReleasable() {
+        // Guards the premise as well as the fix. The plain sum is what the app
+        // used to wait for, and it does not exist on this hinge.
+        let hinge = 132.0
+        let range = makeRange(observedMax: hinge)
+        XCTAssertGreaterThan(130 + range.hysteresis, hinge, "premise: 134° is not reachable on a 132° hinge")
+        XCTAssertTrue(
+            range.isReleasable(threshold: 130, reachableMax: hinge),
+            "with the ceiling applied, a stored 130 must still be able to let go"
+        )
+    }
+
+    // MARK: - Ceiling and threshold bounds
+
+    func testReleaseCeilingKeepsClearOfTheHardStop() {
+        XCTAssertEqual(makeRange(observedMax: 132).releaseCeiling, 131, accuracy: 0.001)
+    }
+
+    func testMaxThresholdLeavesRoomForTheHysteresis() {
+        let range = makeRange(observedMax: 132)
+        XCTAssertEqual(range.maxThreshold, 127, accuracy: 0.001)
+        XCTAssertLessThanOrEqual(range.maxThreshold + range.hysteresis, range.releaseCeiling + 0.001)
+    }
+
+    func testUnknownHingeFallsBackToTheAssumedMaximum() {
+        let range = makeRange(observedMax: 0)
+        XCTAssertEqual(range.knownMax, 130, accuracy: 0.001)
+        XCTAssertEqual(range.maxThreshold, 125, accuracy: 0.001)
+    }
+
+    func testWiderHingeRaisesTheCeiling() {
+        XCTAssertGreaterThan(
+            makeRange(observedMax: 136).maxThreshold,
+            makeRange(observedMax: 130).maxThreshold
+        )
+    }
+
+    // MARK: - Clamping stored values
+
+    func testStoredTrapValueIsPulledDown() {
+        XCTAssertEqual(makeRange(observedMax: 132).clamped(threshold: 130), 127, accuracy: 0.001)
+    }
+
+    func testOrdinaryValuesAreLeftAlone() {
+        let range = makeRange(observedMax: 132)
+        for threshold in [5.0, 45, 90, 120, 127] {
+            XCTAssertEqual(range.clamped(threshold: threshold), threshold, accuracy: 0.001)
+        }
+    }
+
+    func testValueBelowTheFloorIsRaised() {
+        XCTAssertEqual(makeRange(observedMax: 132).clamped(threshold: -20), 5, accuracy: 0.001)
+    }
+
+    func testClampingIsIdempotent() {
+        let range = makeRange(observedMax: 132)
+        let once = range.clamped(threshold: 130)
+        XCTAssertEqual(range.clamped(threshold: once), once, accuracy: 0.001)
+    }
+
+    // MARK: - Degenerate input
+
+    func testNarrowHingeStillOffersAUsableSpan() {
+        // A lid that barely opens, or a first reading taken while nearly shut,
+        // must not collapse the control to a single value.
+        let range = makeRange(observedMax: 12)
+        XCTAssertGreaterThanOrEqual(range.maxThreshold, range.minThreshold + range.minSpan)
+    }
+
+    func testZeroHysteresisReleasesAtTheThreshold() {
+        let range = makeRange(observedMax: 132, hysteresis: 0)
+        XCTAssertEqual(range.releaseAngle(startingAt: 90), 90, accuracy: 0.001)
+    }
+
+    func testHysteresisWiderThanTheHingeIsCappedByTheCeiling() {
+        let range = makeRange(observedMax: 132, hysteresis: 400)
+        XCTAssertEqual(range.releaseAngle(startingAt: 90), range.releaseCeiling, accuracy: 0.001)
+        XCTAssertLessThanOrEqual(range.releaseAngle(startingAt: 90), 132)
+    }
+}


### PR DESCRIPTION
Fixes #28, and covers #12.

## The problem

Releasing an active effect waits for `thresholdAngle + hysteresis`. With `hysteresis = 4` and the
slider ending at `130`, that asks for **134°** — and a MacBook lid stops at about 132°. The angle
does not exist, so the picture stays up for good.

Two things then make it unrecoverable rather than merely annoying: the app is `LSUIElement`, so there
is no Dock icon and no hotkey, and the only control is a menu bar item *behind* the picture. And
`thresholdAngle` is persisted, so quitting and relaunching walks straight back into it. On a 132°
hinge the trap starts at about **128°**, not only at the slider's maximum.

Worth noting that the slider's top value is unsafe on essentially every model — the sensor header in
`LidAngleSensor.swift` itself puts a MacBook at "roughly 130 degrees", which is already below the
134° the release would need.

## The approach

Rather than hard-coding a lower ceiling, the widest angle the sensor has reported is remembered per
machine, and every bound derives from it:

```swift
releaseAngle = min(threshold + hysteresis, observedMax - reachMargin)
```

`noteObserved(angle:)` is fed every real sensor reading before the effect is reconciled, so
`observedMax >= currentAngle` always holds. **A release is therefore only ever asked for at an angle
the lid has already been observed to reach** — the trap cannot be expressed. Hinges differ by model
(132°, 133° and 130.9° were reported on this bug alone) and nothing in the sensor reports its range,
so measuring beats guessing.

Three consequences:

- **The start angle slider** ends at `observedMax - reachMargin - hysteresis` instead of a fixed 130.
  On a 132° hinge that is 127°.
- **A stored value above that is pulled down at launch.** This matters most: an install that is
  already stuck frees itself on the next launch, without the user having to reach a panel they cannot
  see. Values written straight to the plist are covered by the runtime ceiling as well.
- **Timeout defaults to on.** It is the only release that does not require opening the lid all the
  way, and by the time a user wants it, the switch is hidden behind the effect. The old default was
  the dangerous one.

Also in here, because it is the other half of what the bug looks like:

- **Live rendering now holds the capture stream while the effect is on screen.** `updatePrewarm` owns
  the stream and only runs while the lid is closing, so an effect that engaged after the lid settled
  kept its one seeded screenshot for as long as it was up — which is why this reads as a *frozen*
  screen rather than a blurred one. `streamer.start()` is a no-op once running.

The arithmetic moved to `LidAngleRange` in `LidAngleKit` so it can be tested without AppKit or a
sensor.

## Tests

`Tests/LidAngleKitTests/LidAngleRangeTests.swift`, 17 cases: the highest start angle the panel can
offer stays releasable on every hinge maximum reported on this bug (132, 133, 130.9) plus a narrow
125° one; a stored 130 that skipped the clamp is still releasable; the premise itself is guarded
(134 > 132, so the fix is doing the work); ceiling and slider bounds; clamping is idempotent and
leaves ordinary values alone; degenerate input — a barely-open hinge, zero hysteresis, a hysteresis
wider than the hinge.

This adds the package's first `.testTarget`. `swift build` is unaffected by it.

## How this was verified

- `swift build` and `./build.sh` both clean.
- End to end, twice: `defaults write to.maki.MacDuo thresholdAngle -float 130`, launch, and the
  stored value comes back clamped to `125` with `observedMaxAngle` learned as `131.42` from the
  sensor on an M5 MacBook Pro.
- The range arithmetic was additionally run through a standalone harness, 26 assertions over the four
  hinge maxima and the degenerate cases, all passing.

Two gaps, stated plainly:

- **The test file was not compiled locally.** This machine has Command Line Tools but no Xcode, so
  neither `XCTest` nor `Testing` can be imported. The assertions mirror the standalone harness that
  does pass, but CI or a machine with Xcode will be the first to compile them.
- **The live-rendering change was not confirmed visually.** TCC grants Screen Recording per code
  signature, so an ad-hoc dev build is a different app to the system and is refused capture
  (`SCStreamErrorDomain Code=-3801`). That change rests on tracing the call graph — nothing other
  than `updatePrewarm` ever calls `streamer.start()`, and it is skipped once `isActive` — not on
  seeing it work.

## Relation to #9

#9 is open against the same bug and reaches the release problem from a different direction, gating on
a peak angle and on opening velocity. This one instead makes the release angle unable to leave the
reachable range, adds the slider clamp and the launch-time migration that #12 asked for, defaults
Timeout on, and brings tests. The live-rendering fix is the same one-line conclusion both arrive at;
there is only one sensible place for it.

Happy to rebase onto #9, split any part of this out, or close it if the maintainer prefers that
route — whichever lands the fix soonest.
